### PR TITLE
Deprecate repo, point to Pagure

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,14 @@
 wordcloudbot
 ============
 
+Project moved to Pagure_
+------------------------------------------------------
+
+**Please file any issues or pull requests against the Pagure project_!**
+
+.. _Pagure: https://pagure.io/wordcloudbot
+.. _project: https://pagure.io/wordcloudbot
+
 How it's going to work
 ~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
As discussed earlier, this repository was migrated to Pagure to improve accessibility and visibility for other Fedora contributors. This project can be found [here](https://pagure.io/wordcloudbot).

This PR adds a note to the README pointing to the new home for the project, along with instructions to file issues and pull requests against the Pagure repo.
